### PR TITLE
fix(docs-providers): fix broken link to provider

### DIFF
--- a/docs/developers/sdk/provider/overview.md
+++ b/docs/developers/sdk/provider/overview.md
@@ -4,7 +4,7 @@ Provider structs are the core component of the SDK that require the implementor 
 
 ## Example
 
-If we look at the example provider definition [in the template](https://github.com/cloudquery/cq-provider-template/blob/main/resources/provider.go):
+If we look at the example provider definition [in the template](https://github.com/cloudquery/cq-provider-template/blob/main/resources/provider/provider.go):
 
 ```go
 var (


### PR DESCRIPTION
Fixes a broken link in [this doc](https://docs.cloudquery.io/docs/developers/sdk/provider/overview)