### PR TITLE
chore(ci-lint-docs): Add more words to vocabulary

### DIFF
--- a/.github/styles/Vocab/Base/accept.txt
+++ b/.github/styles/Vocab/Base/accept.txt
@@ -1,4 +1,3 @@
-repo
 github
 cloudquery
 CloudQuery
@@ -15,7 +14,6 @@ Config
 openapi
 Docusaurus
 protobuf
-cloudformation
 Pulumi
 postgres
 Postgres
@@ -51,3 +49,16 @@ GraphQL
 subquery
 CIS
 cron
+exfiltrate
+exploitability
+Lightsail
+Grafana
+CloudFormation
+Okta
+browsable
+boldstart
+Yandex
+queryable
+Cybersecurity
+performant
+subnet

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CloudQuery Documentation
 
-This repo contains all documentation on [https://docs.cloudquery.io](https://docs.cloudquery.io).
+This repository contains all documentation on [https://docs.cloudquery.io](https://docs.cloudquery.io).
 
 Contributions are welcome!
 

--- a/docs/cli/policy/language.md
+++ b/docs/cli/policy/language.md
@@ -29,7 +29,7 @@ policy "test-policy" {
 ```
 
 :::tip 
-You can use the file(../relative/path/to/file) in your repo to point to query files or documentation files to make your policy cleaner and more reusable.
+You can use the file(../relative/path/to/file) in your repository to point to query files or documentation files to make your policy cleaner and more reusable.
 :::
 
 ### Policy block

--- a/docs/cli/policy/testing.md
+++ b/docs/cli/policy/testing.md
@@ -38,7 +38,7 @@ This will ensure that the database you are about to snapshot will have valid dat
 Prior to committing to a public repository:
 validate that there is no sensitive information (account IDs, credentials or PII) in the CSV
 
-When working with the [cloudquery-policies/aws](https://github.com/cloudquery-policies/aws/blob/main/tools/find-sensitive-strings.go) repo you can use the script found in the tooling directory:
+When working with the [cloudquery-policies/aws](https://github.com/cloudquery-policies/aws/blob/main/tools/find-sensitive-strings.go) repository you can use the script found in the tooling directory:
 ``` bash
 go run tools/find-sensitive-strings.go 
 ```

--- a/docs/developers/cq-gen.md
+++ b/docs/developers/cq-gen.md
@@ -8,7 +8,7 @@ take a long time. To remedy this issue, the [cq-gen](https://github.com/cloudque
 
 Ensure that you're using `go` version `1.17` by running `go version`. The `cq-gen` tool doesn't support newer versions of `go` yet.
 
-if you haven't created a provider use this command to create a project or alternatively use our [template](https://github.com/cloudquery/cq-provider-template) repo as a base.
+if you haven't created a provider use this command to create a project or alternatively use our [template](https://github.com/cloudquery/cq-provider-template) repository as a base.
 ```bash
 mkdir cq-my-provider
 cd cq-my-provider
@@ -40,7 +40,7 @@ go mod tidy
 
 ## Running cq-gen for the first time.
 
-To run cq-gen you must first create a resource hcl config. As an example we will create the aws cloudformation [stacks](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/cloudformation@v1.20.0/types#Stack)
+To run `cq-gen` you must first create a resource hcl config. As an example we will create the AWS CloudFormation [stacks](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/cloudformation@v1.20.0/types#Stack)
 
 ```hcl
 service = "aws"

--- a/docs/developers/tutorials/creating-new-provider.md
+++ b/docs/developers/tutorials/creating-new-provider.md
@@ -6,7 +6,7 @@ In this tutorial, you will build a new CloudQuery Provider that will interact wi
 
 The best way to bootstrap a new provider is to use the [cq-provider-template](https://github.com/cloudquery/cq-provider-template).
 
-You can either click `Use this template` in GitHub UI or clone the repo and reinitialize the git (as you don't need the template history).
+You can either click `Use this template` in GitHub UI or clone the repository and reinitialize the git (as you don't need the template history).
 
 ```bash
 git clone https://github.com/cloudquery/cq-provider-template cq-provider-github

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,7 @@ cloudquery policy run ./my_policy//ec2/old-stopped-ec2-instances
 It is worth mentioning here that the `cloudquery` CLI also supports running policies from 
 [our official github](https://github.com/cloudquery-policies). The `//` separator serves the same function 
 described above - separating the "path to the policy" from the "path inside the policy". In case of running
-policies from github, it helps the `cloudquery` CLI to know which repo to clone.
+policies from github, it helps the `cloudquery` CLI to know which repository to clone.
 
 So, to run the `foundational_security` **subpolicy** in the `aws` **policy**, we run.
 


### PR DESCRIPTION
Related to https://github.com/cloudquery/cq-website/pull/392.

Updates the vocabulary to allow words from ⬆️  (and also fixes `repo -> repository` and  `aws cloudformation` to `AWS CloudFormation`)