### PR TITLE
fix(docs): Fix lint errors

### DIFF
--- a/docs/cli/drift/configuration.md
+++ b/docs/cli/drift/configuration.md
@@ -75,7 +75,7 @@ The format for filtering resources is `<resource_type>:<ID or tags>`. Here are s
       ]
 ```
 
-If check_resources not specified (which is the default) all resources except the ones matching `ignore_resources` are checked.
+If `check_resources` not specified (which is the default) all resources except the ones matching `ignore_resources` are checked.
 
 #### Resource Blocks
 
@@ -110,7 +110,7 @@ provider "*" {
 
 ### Profiles
 
-Let's talk about profiles. You might have noticed the `drift-example` label in the `drift "drift-example" {` block. This is the name of the profile. It's possible to have multiple profiles defined in the config, and select one using the `--profile` flag. This can be used to configure multiple accounts with different options and completely separate tfstates. If there's only a single profile defined, it's automatically selected. 
+Let's talk about profiles. You might have noticed the `drift-example` label in the `drift "drift-example" {` block. This is the name of the profile. It's possible to have multiple profiles defined in the config, and select one using the `--profile` flag. This can be used to configure multiple accounts with different options and completely separate tfstates. If there's only a single profile defined, it's automatically selected.
 
 :::tip
 It's possible to define multiple profiles for the same account and IaC setup, to distinguish between different ways of running drift on a single cloud configuration.

--- a/docs/cli/drift/overview.md
+++ b/docs/cli/drift/overview.md
@@ -92,7 +92,7 @@ Congratulations, these resources are perfectly in-sync (as far as we can tell) b
 
 The Summary block will show a breakdown of number of resources per category, plus a coverage percentage which is calculated using the formula:
 
-> (number_of_resources_managed_by_terraform / total_number_of_resources) * 100
+> `(number_of_resources_managed_by_terraform / total_number_of_resources) * 100`
 
 Simply put, what’s not covered are the ones that were either missing from your TFstate file (extra resources on cloud) or missing on your AWS account (extra resources on TFstate)
 

--- a/docs/cli/policy/storage.md
+++ b/docs/cli/policy/storage.md
@@ -1,16 +1,17 @@
 # Storage
 
-
-
 Store the results of a `cloudquery policy run` invocation directly in the Postgres Database that holds the configuration data. This enables users to unlock more downstream workflows like monitoring security results in your favorite BI tool and alerting.
 
 To enable storing the policy results:
 
 1. Use the `--enable-db-persistence` flag when invoking
+
+    ```sh
+    cloudquery policy run <policy-name> --enable-db-persistence` 
     ```
-        $ cloudquery policy run <policy-name> --enable-db-persistence` 
-    ```
+
 2. Add a `policy` block to your existing cloudquery block in order to specify what to do with the policy results
+
     ```hcl
     cloudquery {
         policy {
@@ -19,42 +20,40 @@ To enable storing the policy results:
     }
     ```
 
-
 ## Table Schema
 
 All results are stored in the `cloudquery` schema within the postgres database.
 
 ### Table: `cloudquery.policy_executions`
-Holds information about the source of the policy and high level metrics about the execution run 
+
+Holds information about the source of the policy and high level metrics about the execution run
 #### Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
-|id|uuid|Unique identifier for policy run|
-|timestamp|timestamp|Timestamp at which the policy run began|
-|scheme|text|URL scheme that defines from where the policy was loaded|
-|location|text|Full path that defines from where the policy was loaded|
-|policy_name|text|Name of the policy|
-|selector|text|User defined path selector|
-|sha256_hash|text|hash of the policy to be able to compare multiple versions of the same policy|
-|version|text|Version identifier for the policy|
-|checks_total|int|Number of checks that were run|
-|checks_failed|int|Number of checks that failed|
-|checks_passed|int|Number of checks that passed|
-
-
-
+|`id`|`uuid`|Unique identifier for policy run|
+|`timestamp`|`timestamp`|Timestamp at which the policy run began|
+|`scheme`|`text`|URL scheme that defines from where the policy was loaded|
+|`location`|`text`|Full path that defines from where the policy was loaded|
+|`policy_name`|`text`|Name of the policy|
+|`selector`|`text`|User defined path selector|
+|`sha256_hash`|`text`|hash of the policy to be able to compare multiple versions of the same policy|
+|`version`|`text`|Version identifier for the policy|
+|`checks_total`|`int`|Number of checks that were run|
+|`checks_failed`|`int`|Number of checks that failed|
+|`checks_passed`|`int`|Number of checks that passed|
 
 ### Table: `cloudquery.check_results`
-Holds information about the source of the policy and high level metrics about the execution run 
+
+Holds information about the source of the policy and high level metrics about the execution run
 #### Columns
+
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
-|execution_id|uuid|(FK)|
-|execution_timestamp|timestamp|Timestamp at which the check run began|
-|name|text|Name of check|
-|selector|text|Path that fully defines the check within a specific policy |
-|description|text|Description of the check|
-|status|text|Final status of the check|
-|raw_results|jsonb|Raw output of the results returned by the check|
-|error|text|Any errors that occurred during the execution of the check|
-  
+|`execution_id`|`uuid`|(FK)|
+|`execution_timestamp`|`timestamp`|Timestamp at which the check run began|
+|`name`|`text`|Name of check|
+|`selector`|`text`|Path that fully defines the check within a specific policy |
+|`description`|`text`|Description of the check|
+|`status`|`text`|Final status of the check|
+|`raw_results`|`jsonb`|Raw output of the results returned by the check|
+|`error`|`text`|Any errors that occurred during the execution of the check|

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -8,8 +8,7 @@ Similarly to terraform we use HashiCorp [HCL configuration language](https://git
 
 ## Main CloudQuery block
 
-The `cloudquery` block must be specified exactly once per `config.hcl`. This usually looks like: 
-
+The `cloudquery` block must be specified exactly once per `config.hcl`. This usually looks like:
 
 ```hcl
 cloudquery {
@@ -31,21 +30,20 @@ cloudquery {
 }
 ```
 
-#### Arguments:
+### Properties
 
-* **connection** (required) - defines the PostgreSQL URI or DSN connection string to your PostgreSQL database.
-* **plugin_directory** (optional) - directory where CloudQuery will download provider plugins.
-* **policy_directory** (optional) - directory where CloudQuery will download policies.
+* **`connection`** (required) - defines the connections details to your PostgreSQL database.
+* **`plugin_directory`** (optional) - directory where CloudQuery will download provider plugins.
+* **`policy_directory`** (optional) - directory where CloudQuery will download policies.
 
 ## Provider Block
 
 The provider block must be specified one or more times, and should be first specified in the `cloudquery` block.
 
-Each provider has two blocks: 
+Each provider has two blocks:
 
 * `configuration` - The arguments are different from provider to provider and their documentation can be found in [CloudQuery Hub](https://hub.cloudquery.io).
 * `resources` - All resources that this provider supports and can fetch configuration and metadata from.
-
 
 :::tip
 You can have multiple providers of the same type specified here. For example, this can be useful if you want to fetch data from different accounts and you don't have cross-account access.

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -12,9 +12,6 @@ The `cloudquery` block must be specified exactly once per `config.hcl`. This usu
 
 ```hcl
 cloudquery {
-  # plugin_directory = "./cq/providers"
-  # policy_directory = "./cq/policies"
-
   connection {
     type = "postgres"
     username = "postgres"
@@ -30,11 +27,9 @@ cloudquery {
 }
 ```
 
-### Properties
+### Arguments
 
 * **`connection`** (required) - defines the connections details to your PostgreSQL database.
-* **`plugin_directory`** (optional) - directory where CloudQuery will download provider plugins.
-* **`policy_directory`** (optional) - directory where CloudQuery will download policies.
 
 ## Provider Block
 

--- a/docs/developers/sdk/provider/overview.md
+++ b/docs/developers/sdk/provider/overview.md
@@ -24,5 +24,5 @@ func Provider() *provider.Provider {
 }
 ```
 
-Here a new provider struct is defined, which has an empty config and just one resource (the "demo_resource").
+Here a new provider `struct` is defined, which has an empty configuration and just one resource (the `demo_resource`).
 The `DemoResource()` function would be in its own file, `demo_resource.go`, and would define a whole resource and also contain the fetcher functions/resolvers.

--- a/docs/developers/tutorials/creating-new-provider.md
+++ b/docs/developers/tutorials/creating-new-provider.md
@@ -187,11 +187,10 @@ func fetchRepositories(ctx context.Context, meta schema.ClientMeta, parent *sche
 
 The key things here are the table definition and the `fetchRepositories` function.
 
-Each table defines list of columns and their type. CloudQuery SDK by default reads the value from the corresponding [Repository](https://pkg.go.dev/github.com/google/go-github/v41/github#Repository) struct by turning CamelCase fields into snake_case. If a custom transformation is needed, you can use `schema.PathResolver`.
+Each table defines list of columns and their type. CloudQuery SDK by default reads the value from the corresponding [Repository](https://pkg.go.dev/github.com/google/go-github/v41/github#Repository) `struct` by turning CamelCase fields into `snake_case`. If a custom transformation is needed, you can use `schema.PathResolver`.
 
 The third piece of this Tutorial is at [cloudquery/cq-provider-github/tree/tutorial-step-3](https://github.com/cloudquery/cq-provider-github/tree/tutorial-step-3).
 
 To run this in debug mode while you develop, checkout [debugging a provider](https://docs.cloudquery.io/docs/developers/debugging)
 
 Congratulations! This is it, you have your first custom provider!
-


### PR DESCRIPTION
The tool we use for linting the docs released a new version https://github.com/errata-ai/vale/releases/tag/v2.18.0 which caused our linting to fail.

This PR fixes the new issues (we can also pin the tool version in https://github.com/cloudquery/docs/blob/6ea2db6726f93c3d38ed03929714606bdc7047e4/.github/workflows/lint-docs.yml#L18)