### PR TITLE
docs: Cleanup 'plugin_directory' and 'policy_directory'

### DIFF
--- a/docs/cli/fetch/overview.md
+++ b/docs/cli/fetch/overview.md
@@ -24,9 +24,6 @@ in config.hcl:
 
 ```hcl
 cloudquery {
-  plugin_directory = "./cq/providers"
-  policy_directory = "./cq/policies"
-
   provider "aws" {
     source  = ""
     version = "latest"


### PR DESCRIPTION
These fields are deprecated.