### PR TITLE
fix: Remove lowercase boldstart

### DIFF
--- a/.github/styles/Vocab/Base/accept.txt
+++ b/.github/styles/Vocab/Base/accept.txt
@@ -57,7 +57,6 @@ Grafana
 CloudFormation
 Okta
 browsable
-boldstart
 Yandex
 queryable
 Cybersecurity


### PR DESCRIPTION
Follow up to https://github.com/cloudquery/docs/pull/208

I think we should always use `Boldstart` 