### PR TITLE
chore(docs): Sync docs on CLI publish

### DIFF
--- a/.github/workflows/sync-cli-docs.yml
+++ b/.github/workflows/sync-cli-docs.yml
@@ -1,8 +1,10 @@
-name: nightly-doc
+name: Sync CLI docs
 on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+  repository_dispatch:
+    types: [sync-docs]
 jobs:
   doc-generate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds support for syncing the CLI docs after a new version of CloudQuery CLI was published