### PR TITLE
fix: Remove deprecated commands before syncing docs

### DIFF
--- a/.github/workflows/sync-cli-docs.yml
+++ b/.github/workflows/sync-cli-docs.yml
@@ -17,6 +17,8 @@ jobs:
           version: latest
       - name: Re-generate docs
         run: |
+          rm -rf docs/cli/commands
+          mkdir -p docs/cli/commands
           cd docs/cli/commands
           cloudquery doc .
       - name: Create Pull Request


### PR DESCRIPTION
Fixes https://github.com/cloudquery/docs/issues/228 and also removes deprecated commands like `provider download`