### PR TITLE
chore: Fix broken-links-checker on CI

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Check for broken links
         run: |
+          set -o pipefail
+
           npx broken-link-checker -f -r -v -o \
             --exclude linkedin \
             --exclude "cloudquery.io/discord" \


### PR DESCRIPTION
Exit code from the script was eaten by `grep`, small fix to lift exit code to github action